### PR TITLE
fix: add slash to google auth redirect uri

### DIFF
--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -63,5 +63,5 @@ export type Auth = typeof auth;
 export const googleAuth = google(auth, {
   clientId: config.env.GOOGLE_CLIENT_ID,
   clientSecret: config.env.GOOGLE_CLIENT_SECRET,
-  redirectUri: `${config.env.HOST_URL}api/auth/google/callback`,
+  redirectUri: `${config.env.HOST_URL}/api/auth/google/callback`,
 });


### PR DESCRIPTION
This fixes the "Sign in with Google" page showing "Access blocked: Authorization Error"